### PR TITLE
Use php instead of phpdbg for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## What changed
- switched the `coverage` Make target from `phpdbg` to `php`

## Why
- aligns this skeleton with the prepared contributte/contributte#73 maintenance update and avoids relying on `phpdbg` for coverage runs

Refs #73